### PR TITLE
Switch trigger to void

### DIFF
--- a/include/StepperMotorReadback.h
+++ b/include/StepperMotorReadback.h
@@ -103,7 +103,7 @@ namespace ChimeraTK::MotorDriver {
     ReadbackHandler(std::shared_ptr<Motor> motor, ModuleGroup* owner, const std::string& name,
         const std::string& description, const std::string& triggerPath);
 
-    ScalarPushInput<uint64_t> trigger{};
+    VoidInput trigger{};
 
     // Diagnostics
     ScalarOutput<float> actualCycleTime{

--- a/src/StepperMotorReadback.cc
+++ b/src/StepperMotorReadback.cc
@@ -43,7 +43,8 @@ namespace ChimeraTK::MotorDriver {
       positiveEndSwitch = ReferenceSwitch{this, "positiveEndSwitch", "Data of the positive end switch", {"MOTOR"}};
       negativeEndSwitch = ReferenceSwitch{this, "negativeEndSwitch", "Data of the negative end switch", {"MOTOR"}};
     }
-    trigger = ScalarPushInput<uint64_t>{this, triggerPath, "", "Trigger to initiate reading from HW", {"MOT_TRIG"}};
+    trigger = VoidInput{
+        this, triggerPath, "Trigger to initiate reading from HW", std::unordered_set<std::string>{"MOT_TRIG"}};
   }
 
   /********************************************************************************************************************/

--- a/tests/testMotorDriver.cc
+++ b/tests/testMotorDriver.cc
@@ -71,7 +71,7 @@ BOOST_FIXTURE_TEST_CASE(testMoving, TestFixture) {
   ChimeraTK::TestFacility testFacility{testServer};
   testFacility.runApplication();
 
-  auto trigger = testFacility.getScalar<uint64_t>("/Motor/readback/tick");
+  auto trigger = testFacility.getVoid("/Motor/readback/tick");
   auto motorState = testFacility.getScalar<std::string>("/Motor/readback/status/state");
 
   // Enable he dummy motor
@@ -143,7 +143,7 @@ BOOST_FIXTURE_TEST_CASE(testStartupWithSimpleCalibration, TestFixture) {
   ChimeraTK::TestFacility testFacility{testServer};
   testFacility.runApplication();
 
-  auto trigger = testFacility.getScalar<uint64_t>("Motor/readback/tick");
+  auto trigger = testFacility.getVoid("Motor/readback/tick");
   auto motorState = testFacility.getScalar<std::string>("Motor/readback/status/state");
 
   trigger.write();


### PR DESCRIPTION
Instead of requiring a specific type. So we can basically hook up
anything into there without taking care of the source type
