### PR TITLE
wip/release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ cmake_minimum_required(VERSION 3.16)
 include(GNUInstallDirs)
 
 set(${PROJECT_NAME}_MAJOR_VERSION 00)
-set(${PROJECT_NAME}_MINOR_VERSION 07)
-set(${PROJECT_NAME}_PATCH_VERSION 01)
+set(${PROJECT_NAME}_MINOR_VERSION 08)
+set(${PROJECT_NAME}_PATCH_VERSION 00)
 include(cmake/set_version_numbers.cmake)
 
 find_package(ChimeraTK-ApplicationCore 01.00 REQUIRED)

--- a/include/StepperMotorCtrl.h
+++ b/include/StepperMotorCtrl.h
@@ -151,7 +151,7 @@ namespace ChimeraTK::MotorDriver {
      */
     using FunctionMapEntry = std::tuple<bool, std::string, std::function<void(void)>>;
     std::map<TransferElementID, FunctionMapEntry> _funcMap{};
-    void addMapping(TransferElementAbstractor& element, bool writeOnRecovery, std::function<void(void)> func);
+    void addMapping(TransferElementAbstractor& element, bool writeOnRecovery, const std::function<void(void)>& func);
 
     VoidInput deviceBecameFunctional;
     VoidInput trigger{};

--- a/include/StepperMotorCtrl.h
+++ b/include/StepperMotorCtrl.h
@@ -135,7 +135,7 @@ namespace ChimeraTK::MotorDriver {
   class ControlInputHandler : public ApplicationModule {
    public:
     ControlInputHandler(ModuleGroup* owner, const std::string& name, const std::string& description,
-        std::shared_ptr<Motor> motor, DeviceModule* deviceModule);
+        std::shared_ptr<Motor> motor, const std::string& triggerPath, DeviceModule* deviceModule);
 
     void prepare() override;
     void mainLoop() override;
@@ -154,6 +154,7 @@ namespace ChimeraTK::MotorDriver {
     void addMapping(TransferElementAbstractor& element, bool writeOnRecovery, std::function<void(void)> func);
 
     VoidInput deviceBecameFunctional;
+    VoidInput trigger{};
 
     MotorControl control{this, "control", "Control words of the motor", {"MOTOR"}};
     PositionSetpoint positionSetpoint{this, "positionSetpoint", "Position setpoints", {"MOTOR"}};
@@ -164,6 +165,7 @@ namespace ChimeraTK::MotorDriver {
     Notification notification{this, "notification", "User notification", {"MOTOR"}};
     DummySignals dummySignals{this, "dummySignals", " Signals triggering the dummy motor", {"DUMMY"}};
     // CalibrationCommands _calibrationCommands;
+    ScalarOutput<std::string> motorState{this, "../readback/status/state", "State of motor control", {"MOTOR"}};
 
     // Callbacks for the BasiStepperMotor
     void enableCallback();

--- a/include/StepperMotorReadback.h
+++ b/include/StepperMotorReadback.h
@@ -53,7 +53,6 @@ namespace ChimeraTK::MotorDriver {
     ScalarOutput<int> isIdle{
         this, "isIdle", "", "Flags if system is idle and a movement or calibration can be started"};
 
-    ScalarOutput<std::string> state{this, "state", "", "State of the motor driver"};
     ScalarOutput<int> errorId{this, "errorId", "", "Error ID of the motor driver"};
 
     ScalarOutput<int> isFullStepping{

--- a/src/StepperMotorCtrl.cc
+++ b/src/StepperMotorCtrl.cc
@@ -175,8 +175,6 @@ namespace ChimeraTK::MotorDriver {
     if(_motor->getMotorParameters().motorType == StepperMotorType::LINEAR) {
       appendCalibrationToMap();
     }
-
-    writeAll();
   }
 
   /********************************************************************************************************************/
@@ -195,14 +193,15 @@ namespace ChimeraTK::MotorDriver {
   void ControlInputHandler::mainLoop() {
     auto inputGroup = this->readAnyGroup();
 
-    // Write once to propagate inital values
-    writeAll();
 
     // before anything else, wait for the deviceBecameFunctional trigger
     // then flush out all values that are written during recovery
 
     inputGroup.readUntil(deviceBecameFunctional.getId());
     writeRecoveryValues();
+
+    // Write once to propagate inital values
+    writeAll();
 
     while(true) {
       notification.message = "";

--- a/src/StepperMotorCtrl.cc
+++ b/src/StepperMotorCtrl.cc
@@ -32,7 +32,7 @@ namespace ChimeraTK::MotorDriver {
   /********************************************************************************************************************/
 
   void ControlInputHandler::addMapping(
-      TransferElementAbstractor& element, bool writeOnRecovery, std::function<void(void)> function) {
+      TransferElementAbstractor& element, bool writeOnRecovery, const std::function<void(void)>& function) {
     _funcMap[element.getId()] = {writeOnRecovery, element.getName(), function};
   }
 

--- a/src/StepperMotorCtrl.cc
+++ b/src/StepperMotorCtrl.cc
@@ -151,7 +151,7 @@ namespace ChimeraTK::MotorDriver {
         notification.message = "Could not set max position limits: " + ChimeraTK::MotorDriver::toString(code);
       }
     });
-    addMapping(swLimits.minPositionInSteps, ::detail::WRITE_ON_RECOVERY, [this] {
+    addMapping(swLimits.minPositionInSteps, ::detail::SKIP_ON_RECOVERY, [this] {
       auto code = _motor->get()->setMinPositionLimitInSteps(swLimits.minPositionInSteps);
       if(code != ExitStatus::SUCCESS) {
         notification.message = "Could not set min position limits: " + ChimeraTK::MotorDriver::toString(code);

--- a/src/StepperMotorModule.cc
+++ b/src/StepperMotorModule.cc
@@ -15,7 +15,8 @@ namespace ChimeraTK::MotorDriver {
             "&monitorRegister=" + motor->getMotorParameters().moduleName + "/WORD_PROJ_VERSION" +
             "&driverId=" + std::to_string(motor->getMotorParameters().driverId) + ")",
         triggerPath},
-    ctrlInputHandler{this, "controlInput", "Handles the control input to the motor driver.", motor, &motorProxyDevice},
+    ctrlInputHandler{
+        this, "controlInput", "Handles the control input to the motor driver.", motor, triggerPath, &motorProxyDevice},
     readbackHandler{motor, this, "readback", "Signals read from the motor driver", triggerPath, &motorProxyDevice} {
     if(!initScriptPath.empty()) {
       initHandler = std::make_unique<ScriptedInitHandler>(this, "ExternalScript", "", initScriptPath, motorProxyDevice);

--- a/src/StepperMotorReadback.cc
+++ b/src/StepperMotorReadback.cc
@@ -117,7 +117,6 @@ namespace ChimeraTK::MotorDriver {
     position.targetValue = _motor->get()->recalculateStepsInUnits(position.targetValueInSteps);
 
     status.isIdle = _motor->get()->isSystemIdle();
-    status.state = _motor->get()->getState();
     swLimits.isEnabled = _motor->get()->getSoftwareLimitsEnabled();
     swLimits.maxPositionInSteps = _motor->get()->getMaxPositionLimitInSteps();
     swLimits.minPositionInSteps = _motor->get()->getMinPositionLimitInSteps();


### PR DESCRIPTION
- ctrl: No initial values until motor is ready
- Move status into control module
- Do not set minPositionInSteps on device recovers
- Minor optimisation regarding parameter passing
- Fix tests for recent changes
- chore: Bump minor version
