### PR TITLE
fix: Clean-up status handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(GNUInstallDirs)
 
 set(${PROJECT_NAME}_MAJOR_VERSION 00)
 set(${PROJECT_NAME}_MINOR_VERSION 08)
-set(${PROJECT_NAME}_PATCH_VERSION 01)
+set(${PROJECT_NAME}_PATCH_VERSION 02)
 include(cmake/set_version_numbers.cmake)
 
 find_package(ChimeraTK-ApplicationCore 01.00 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ include(cmake/enable_doxygen_documentation.cmake)
 
 
 # The shared library
-set(SRC StepperMotorModule.cc StepperMotorCtrl.cc StepperMotorReadback.cc)
+set(SRC StepperMotorModule.cc StepperMotorCtrl.cc StepperMotorReadback.cc StatusModule.cc)
 foreach(SOURCE ${SRC})
     set(LIBRARY_SOURCES ${LIBRARY_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/src/${SOURCE})
 endforeach()

--- a/include/StatusModule.h
+++ b/include/StatusModule.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#pragma once
+
+#include <ChimeraTK/ApplicationCore/ApplicationModule.h>
+#include <ChimeraTK/ApplicationCore/ScalarAccessor.h>
+
+// This module makes sure that all the status information about the motor never changes in validity.
+// It should always be DataValidity::ok since it is information about the device.
+namespace ChimeraTK {
+  struct StatusModule : public ApplicationModule {
+    explicit StatusModule(ModuleGroup* owner);
+
+    ScalarOutput<std::string> message{this, "../controlInput/notification/message", "n/a", "", {"MOTOR"}};
+    ScalarOutput<Boolean> hasMessage{this, "../controlInput/notification/hasMessage", "n/a", "", {"MOTOR"}};
+    ScalarOutput<std::string> motorState{this, "../readback/status/state", "n/a", "", {"MOTOR"}};
+
+    ScalarPushInput<std::string> messageIn{this, "message", "n/a", ""};
+    ScalarPushInput<std::string> motorStateIn{this, "motorState", "n/a", ""};
+
+    DataValidity getDataValidity() const override;
+    void mainLoop() override;
+  };
+} // namespace ChimeraTK

--- a/include/StepperMotorCtrl.h
+++ b/include/StepperMotorCtrl.h
@@ -95,17 +95,6 @@ namespace ChimeraTK::MotorDriver {
 
   /********************************************************************************************************************/
 
-  /// Notifications to the user
-  struct Notification : public VariableGroup {
-    using VariableGroup::VariableGroup;
-
-    ScalarOutput<ChimeraTK::Boolean> hasMessage{
-        this, "hasMessage", "", "Warning flag, true when an invalid input has been issued."};
-    ScalarOutput<std::string> message{this, "message", "", "Message for user notification from ControlInput module"};
-  };
-
-  /********************************************************************************************************************/
-
   /// User-definable limits
   struct UserLimits : public VariableGroup {
     using VariableGroup::VariableGroup;
@@ -149,9 +138,10 @@ namespace ChimeraTK::MotorDriver {
      * function of the MotorDriverCard library. This allows to pass on
      * the changed PV to the library by the ID returned from readAny().
      */
-    using FunctionMapEntry = std::tuple<bool, std::string, std::function<void(void)>>;
+    using FunctionMapEntry = std::tuple<bool, std::string, std::function<std::string(void)>>;
     std::map<TransferElementID, FunctionMapEntry> _funcMap{};
-    void addMapping(TransferElementAbstractor& element, bool writeOnRecovery, const std::function<void(void)>& func);
+    void addMapping(
+        TransferElementAbstractor& element, bool writeOnRecovery, const std::function<std::string(void)>& func);
 
     VoidInput deviceBecameFunctional;
     VoidInput trigger{};
@@ -162,19 +152,20 @@ namespace ChimeraTK::MotorDriver {
     SoftwareLimitCtrl swLimits{this, "swLimits", "Control data of SW limits", {"MOTOR"}};
     ReferenceSettings referenceSettings{
         this, "referenceSettings", "Settings to define the position reference", {"MOTOR"}};
-    Notification notification{this, "notification", "User notification", {"MOTOR"}};
     DummySignals dummySignals{this, "dummySignals", " Signals triggering the dummy motor", {"DUMMY"}};
     // CalibrationCommands _calibrationCommands;
-    ScalarOutput<std::string> motorState{this, "../readback/status/state", "State of motor control", {"MOTOR"}};
+    ScalarOutput<std::string> message{
+        this, "../StatusPropagator/message", "n/a", "Message for user notification from ControlInput module"};
+    ScalarOutput<std::string> motorState{this, "../StatusPropagator/motorState", "n/a", "State of motor control"};
 
     // Callbacks for the BasiStepperMotor
-    void enableCallback();
-    void disableCallback();
-    void startCallback();
+    std::string enableCallback();
+    std::string disableCallback();
+    std::string startCallback();
 
     // Callbacks for the LinearStepperMotor
-    void calibrateCallback();
-    void determineToleranceCallback();
+    std::string calibrateCallback();
+    std::string determineToleranceCallback();
 
     // ReadAnyGroup _inputGroup{};
     std::shared_ptr<Motor> _motor;

--- a/include/StepperMotorModule.h
+++ b/include/StepperMotorModule.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "Motor.h"
+#include "StatusModule.h"
 #include "StepperMotorCtrl.h"
 #include "StepperMotorReadback.h"
 
@@ -23,5 +24,6 @@ namespace ChimeraTK::MotorDriver {
     std::unique_ptr<ScriptedInitHandler> initHandler;
     ControlInputHandler ctrlInputHandler;
     ReadbackHandler readbackHandler;
+    StatusModule statusModule{this};
   };
 } // namespace ChimeraTK::MotorDriver

--- a/src/StatusModule.cc
+++ b/src/StatusModule.cc
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#include "StatusModule.h"
+
+ChimeraTK::StatusModule::StatusModule(ModuleGroup* owner)
+: ApplicationModule(owner, "StatusPropagator", "Module to propagate states") {}
+
+ChimeraTK::DataValidity ChimeraTK::StatusModule::getDataValidity() const {
+  return DataValidity::ok;
+}
+
+void ChimeraTK::StatusModule::mainLoop() {
+  auto group = readAnyGroup();
+  TransferElementID id{};
+  do {
+    if(!id.isValid() || id == messageIn.getId()) {
+      message.writeIfDifferent(std::string(messageIn));
+      hasMessage.writeIfDifferent(!std::string(message).empty());
+    }
+
+    if(!id.isValid() || id == motorStateIn.getId()) {
+      motorState.writeIfDifferent(std::string(motorStateIn));
+    }
+    id = group.readAny();
+  } while(true);
+}


### PR DESCRIPTION
Centralise message writing in the main loop after running the from
function map, add a module on top that strips the data validity flag
since the status messages are not depending on the validity of the motor
